### PR TITLE
Improve PASTEL error handling (AI-1285)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "google-cloud-storage>=3.2.0",
     "torch>=2.7.1",
     "pytest-asyncio>=1.0.0",
+    "tenacity>=8.5.0",
 ]
 
 [[tool.uv.index]]

--- a/src/harmful_claim_finder/pastel/optimise_weights.py
+++ b/src/harmful_claim_finder/pastel/optimise_weights.py
@@ -59,8 +59,10 @@ def learn_weights(
 
     examples = load_examples(training_data_filename)
     answers = asyncio.run(pasteliser.get_answers_to_questions([e[0] for e in examples]))
-    predictions = pasteliser.quantify_answers(answers)
-    targs = [e[1] for e in examples]
+    predictions = pasteliser.quantify_answers(list(answers.values()))
+
+    examples_with_scores = [ex for ex in examples if ex[0] in answers.keys()]
+    targs = [e[1] for e in examples_with_scores]
     targs_arr = np.array(targs)
     pred_arr = np.array(predictions)
     weights = lin_reg(pred_arr, targs_arr)

--- a/src/harmful_claim_finder/pastel/pastel.py
+++ b/src/harmful_claim_finder/pastel/pastel.py
@@ -282,14 +282,17 @@ class Pastel:
         """Use the Pastel questions and weights model to generate
         a score for each of a list of sentences."""
         answers = await self.get_answers_to_questions(sentences)
-        scores = self.get_scores_from_answers(list(answers.values()))
+        if answers:
+            scores = self.get_scores_from_answers(list(answers.values()))
+        else:
+            scores = np.array([])
 
         scores_dict = {}
         for sentence, score in zip(answers.keys(), scores):
             scores_dict[sentence] = float(score)
 
         for sentence in sentences:
-            if sentence not in scores:
+            if sentence not in scores_dict:
                 scores_dict[sentence] = 0.0
 
         return np.array([scores_dict[sentence] for sentence in sentences])

--- a/tests/harmful_claim_finder/test_pastel.py
+++ b/tests/harmful_claim_finder/test_pastel.py
@@ -114,7 +114,7 @@ async def test_retries(mock_run_prompt: AsyncMock, pastel_instance: Pastel) -> N
         ),
         param(
             ["s1", "s2"],
-            [ValueError, ValueError()],
+            [ValueError(), ValueError()],
             {},
             id="All sentences fail",
         ),

--- a/tests/harmful_claim_finder/test_pastel.py
+++ b/tests/harmful_claim_finder/test_pastel.py
@@ -1,11 +1,10 @@
 import json
 import tempfile
+from unittest.mock import AsyncMock, patch
 
 import numpy as np
 import pytest
-
 from pytest import mark, param
-from unittest.mock import patch, AsyncMock
 
 from harmful_claim_finder.pastel.pastel import BiasType, Pastel
 
@@ -122,7 +121,10 @@ async def test_retries(mock_run_prompt: AsyncMock, pastel_instance: Pastel) -> N
     ],
 )
 async def test_get_answers_to_questions(
-    sentences, return_values, expected, pastel_instance: Pastel
+    sentences: list[str],
+    return_values: list[dict[str, float] | BaseException],
+    expected: dict[str, dict[str, float]],
+    pastel_instance: Pastel,
 ):
     with patch.object(
         pastel_instance, "_get_answers_for_single_sentence", side_effect=return_values
@@ -154,7 +156,12 @@ async def test_get_answers_to_questions(
         ),
     ],
 )
-async def test_make_predictions(sentences, answers, expected, pastel_instance: Pastel):
+async def test_make_predictions(
+    sentences: list[str],
+    answers: dict[str, dict[str, float]],
+    expected: np.ndarray,
+    pastel_instance: Pastel,
+):
     with patch.object(
         pastel_instance, "get_answers_to_questions", return_value=answers
     ):

--- a/tests/harmful_claim_finder/test_pastel.py
+++ b/tests/harmful_claim_finder/test_pastel.py
@@ -4,6 +4,9 @@ import tempfile
 import numpy as np
 import pytest
 
+from pytest import mark, param
+from unittest.mock import patch, AsyncMock
+
 from harmful_claim_finder.pastel.pastel import BiasType, Pastel
 
 # mypy: ignore-errors
@@ -78,3 +81,82 @@ def test_quantify_answers(pastel_instance: Pastel) -> None:
     assert all(x == 1 for x in numeric_answers[:, 0])
     # Given no sentences, return no answers
     assert pastel_instance.quantify_answers([]).shape[0] == 0
+
+
+@patch(
+    "harmful_claim_finder.pastel.pastel.run_prompt",
+    side_effect=ValueError("Gemini failed"),
+)
+async def test_retries(mock_run_prompt: AsyncMock, pastel_instance: Pastel) -> None:
+    sentence = "This is a claim."
+    try:
+        await pastel_instance._get_answers_for_single_sentence(sentence)
+        assert False
+    except Exception:
+        assert True
+
+    assert mock_run_prompt.call_count == 3
+
+
+@mark.parametrize(
+    "sentences,return_values,expected",
+    [
+        param(
+            ["s1", "s2"],
+            [{Q1: 1.0, Q2: 1.0}, {Q1: 1.0, Q2: 0.0}],
+            {"s1": {Q1: 1.0, Q2: 1.0}, "s2": {Q1: 1.0, Q2: 0.0}},
+            id="Normal case",
+        ),
+        param(
+            ["s1", "s2"],
+            [{Q1: 1.0, Q2: 1.0}, ValueError()],
+            {"s1": {Q1: 1.0, Q2: 1.0}},
+            id="One sentence fails",
+        ),
+        param(
+            ["s1", "s2"],
+            [ValueError, ValueError()],
+            {},
+            id="All sentences fail",
+        ),
+    ],
+)
+async def test_get_answers_to_questions(
+    sentences, return_values, expected, pastel_instance: Pastel
+):
+    with patch.object(
+        pastel_instance, "_get_answers_for_single_sentence", side_effect=return_values
+    ):
+        answers = await pastel_instance.get_answers_to_questions(sentences)
+        assert answers == expected
+
+
+@mark.parametrize(
+    "sentences,answers,expected",
+    [
+        param(
+            ["s1", "s2"],
+            {"s1": {Q1: 0.0, Q2: 1.0}, "s2": {Q1: 0.0, Q2: 0.5}},
+            np.array([3.0, 2.0]),
+            id="Normal case",
+        ),
+        param(
+            ["s1", "s2"],
+            {"s1": {Q1: 0.0, Q2: 1.0}},
+            np.array([3.0, 0.0]),
+            id="One sentence fails",
+        ),
+        param(
+            ["s1", "s2"],
+            {},
+            np.array([0.0, 0.0]),
+            id="All sentences fail",
+        ),
+    ],
+)
+async def test_make_predictions(sentences, answers, expected, pastel_instance: Pastel):
+    with patch.object(
+        pastel_instance, "get_answers_to_questions", return_value=answers
+    ):
+        predictions = await pastel_instance.make_predictions(sentences)
+        assert all(predictions == expected)

--- a/uv.lock
+++ b/uv.lock
@@ -311,6 +311,7 @@ dependencies = [
     { name = "scipy" },
     { name = "scipy-stubs" },
     { name = "structlog" },
+    { name = "tenacity" },
     { name = "torch" },
     { name = "transformers" },
 ]
@@ -340,6 +341,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.15.3" },
     { name = "scipy-stubs", specifier = ">=1.16.0.0" },
     { name = "structlog", specifier = ">=23.1.0" },
+    { name = "tenacity", specifier = ">=8.5.0" },
     { name = "torch", specifier = ">=2.7.1" },
     { name = "transformers", specifier = ">=4.53.1" },
 ]


### PR DESCRIPTION
[AI-1285](https://linear.app/fullfact/issue/AI-1345/improve-pastel-error-handling)

Improves the way error handling works for PASTEL. 

Specifically, pastel will now return scores for all the sentences where there were no errors.

But it will still retry up to three times each failing attempt, with exponential backoff.