### PR TITLE
Remove country code logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,7 @@ if __name__ == "__main__":
     }
     # These are the keywords that we use to decide topics for each sentence.
 
-    countries = ["GBR", "USA"]
-    # These are the countries of interest to an organisation
-    # If the transcript refers to other countries and not these, it's PASTEL score will be negatively affected.
-
-    result = asyncio.run(get_claims(kw, sentences, countries), debug=True)
+    result = asyncio.run(get_claims(kw, sentences), debug=True)
     pp([claim.model_dump() for claim in result])
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "scipy>=1.15.3",
     "rapidfuzz>=3.13.0",
     "scipy-stubs>=1.16.0.0",
-    "pycountry>=24.6.1",
     "transformers>=4.53.1",
     "google-cloud-storage>=3.2.0",
     "torch>=2.7.1",

--- a/scripts/demos/pastel_demo.py
+++ b/scripts/demos/pastel_demo.py
@@ -65,7 +65,7 @@ def demo_inference() -> None:
         "Environment Secretary Steve Reed has previously said government intervention "
         "in Thames Water would 'cost billions and take years'.",
     ]
-    cw_predictor = pastel_inference.CheckworthyClaimDetector(countries=["GBR"])
+    cw_predictor = pastel_inference.CheckworthyClaimDetector()
     scores = asyncio.run(cw_predictor.score_sentences(examples))
     _ = [print(f"{s:4.1f} \t{e}") for s, e in sorted(zip(scores, examples))]
 

--- a/scripts/demos/transcript_inference_demo.py
+++ b/scripts/demos/transcript_inference_demo.py
@@ -74,7 +74,5 @@ if __name__ == "__main__":
         "migration": ["crossings", "migrants", "immigration", "migration"],
     }
 
-    countries = ["GBR", "USA"]
-
-    result = asyncio.run(get_claims(kw, sentences, countries), debug=True)
+    result = asyncio.run(get_claims(kw, sentences), debug=True)
     pp([claim.model_dump() for claim in result])

--- a/scripts/demos/video_inference_demo.py
+++ b/scripts/demos/video_inference_demo.py
@@ -30,9 +30,7 @@ def find_checkworthy_claims() -> None:
     }
     for video_uri in videos:
         try:
-            claims = asyncio.run(
-                get_claims(video_id, video_uri, kw, ["GBR", "USA"]), debug=True
-            )
+            claims = asyncio.run(get_claims(video_id, video_uri, kw), debug=True)
             output[video_uri] = [claim.model_dump(mode="json") for claim in claims]
         except Exception as exc:
             print(f"Something went wrong with {video_uri}: {repr(exc)}")

--- a/src/harmful_claim_finder/pastel/README.md
+++ b/src/harmful_claim_finder/pastel/README.md
@@ -26,12 +26,6 @@ Each of these functions return a float.
 
 Currently, the production model does not use any of these functions, but examples would be functions which see if a text is short, or contains a number.
 
-### Countries
-
-PASTEL will penalise sentences if they relate to any country other than those specified as relevant by an organisation.
-
-For example, if your organisation's country was "USA", and a sentence says "The bond markets in China have hit an all time high", then that sentence will have it's score reduced by 1.
-
 ## Saving/loading models
 
 Models are stored a JSON files. To achieve this, Callable functions are converted to strings (i.e. the function names) in `save_model()`. When re-loaded (i.e `load_model()`), any key that matches a function name in `pastel_functions.py` is converted to a Callable. Similarly, the bias term is saved with the key `bias` and that's converted to the special bias type on load.

--- a/src/harmful_claim_finder/pastel/inference.py
+++ b/src/harmful_claim_finder/pastel/inference.py
@@ -18,24 +18,8 @@ _logger = logging.getLogger(__name__)
 class CheckworthyClaimDetector:
     """A class for detecting which claims may be worth checking"""
 
-    def __init__(self, countries: list[str]) -> None:
-        _pastel = pastel.Pastel.load_model(str(CHECKWORTHY_MODEL_FILE))
-        self.pastel = self.add_country_question_to_model_dict(_pastel, countries)
-
-    @staticmethod
-    def add_country_question_to_model_dict(
-        _pastel: pastel.Pastel, countries: list[str] | None
-    ) -> pastel.Pastel:
-        # Add the country question, which won't be in the file
-        if countries:
-            country_list = "[" + ", ".join(countries) + "]"
-            new_question = (
-                "Identify any country named in the sentence, ignoring cities, regions and other places. "
-                f"If this sentence mentions any country in this list: {country_list} answer 'no'. If it doesn't name any country at all then also answer 'no'. "
-                "If you're not sure, answer 'no'. Only answer 'yes' if it mentions or is clearly about some other country not on that list. "
-            )
-            _pastel.model[new_question] = -1.0
-        return _pastel
+    def __init__(self) -> None:
+        self.pastel = pastel.Pastel.load_model(str(CHECKWORTHY_MODEL_FILE))
 
     async def score_sentences(
         self, sentences: list[str], max_attempts: int = 3

--- a/src/harmful_claim_finder/pastel/inference.py
+++ b/src/harmful_claim_finder/pastel/inference.py
@@ -19,16 +19,23 @@ class CheckworthyClaimDetector:
     """A class for detecting which claims may be worth checking"""
 
     def __init__(self, countries: list[str]) -> None:
-        self.pastel = pastel.Pastel.load_model(str(CHECKWORTHY_MODEL_FILE))
-        # Add the country question, which won't be in the file
-        country_list = "[" + ", ".join(countries) + "]"
-        new_question = (
-            "Identify any country named in the sentence, ignoring cities, regions and other places. "
-            f"If this sentence mentions any country in this list: {country_list} answer 'no'. If it doesn't name any country at all then also answer 'no'. "
-            "If you're not sure, answer 'no'. Only answer 'yes' if it mentions or is clearly about some other country not on that list. "
-        )
+        _pastel = pastel.Pastel.load_model(str(CHECKWORTHY_MODEL_FILE))
+        self.pastel = self.add_country_question_to_model_dict(_pastel, countries)
 
-        self.pastel.model[new_question] = -1.0
+    @staticmethod
+    def add_country_question_to_model_dict(
+        _pastel: pastel.Pastel, countries: list[str] | None
+    ) -> pastel.Pastel:
+        # Add the country question, which won't be in the file
+        if countries:
+            country_list = "[" + ", ".join(countries) + "]"
+            new_question = (
+                "Identify any country named in the sentence, ignoring cities, regions and other places. "
+                f"If this sentence mentions any country in this list: {country_list} answer 'no'. If it doesn't name any country at all then also answer 'no'. "
+                "If you're not sure, answer 'no'. Only answer 'yes' if it mentions or is clearly about some other country not on that list. "
+            )
+            _pastel.model[new_question] = -1.0
+        return _pastel
 
     async def score_sentences(
         self, sentences: list[str], max_attempts: int = 3

--- a/src/harmful_claim_finder/transcript_inference.py
+++ b/src/harmful_claim_finder/transcript_inference.py
@@ -1,7 +1,6 @@
 import logging
 import time
 
-
 from harmful_claim_finder.keyword_filter.topic_keyword_filter import TopicKeywordFilter
 from harmful_claim_finder.pastel.inference import CheckworthyClaimDetector
 from harmful_claim_finder.utils.models import (

--- a/src/harmful_claim_finder/video_inference.py
+++ b/src/harmful_claim_finder/video_inference.py
@@ -13,7 +13,6 @@ async def get_claims(
     video_id: UUID,
     video_uri: str,
     keywords: dict[str, list[str]],
-    country_codes: list[str],
 ) -> list[VideoClaims]:
     """
     Retrieve claims from a video directly.
@@ -32,9 +31,6 @@ async def get_claims(
                 "health": ["doctor", "hospital"],
             }
             ```
-        country_codes (list[str]):
-            A list of 3-letter ISO country codes for the current sentences.
-            e.g. `["GBR", "USA"]`
 
     Returns:
         list[VideoClaims]
@@ -43,7 +39,7 @@ async def get_claims(
     claims: list[VideoClaims] = await extract_claims_from_video(
         video_id, video_uri, keywords
     )
-    pastel = CheckworthyClaimDetector(countries=country_codes)
+    pastel = CheckworthyClaimDetector()
     claims_text = [claim.claim for claim in claims]
     scores = await pastel.score_sentences(claims_text, max_attempts=2)
 

--- a/tests/harmful_claim_finder/test_video_inference.py
+++ b/tests/harmful_claim_finder/test_video_inference.py
@@ -58,5 +58,5 @@ async def test_output_format(mock_extract_claims, mock_pastel):
     mock_pastel_class.score_sentences.return_value = [0.9, 0.2, 0]
     mock_pastel.return_value = mock_pastel_class
     kw = {"topic": ["keyword"]}
-    output = await get_claims(fake_id, "video_uri", kw, ["GBR"])
+    output = await get_claims(fake_id, "video_uri", kw)
     assert output == scored_claims

--- a/uv.lock
+++ b/uv.lock
@@ -303,7 +303,6 @@ dependencies = [
     { name = "google-cloud-storage" },
     { name = "google-genai" },
     { name = "json-repair" },
-    { name = "pycountry" },
     { name = "pydantic" },
     { name = "pytest-asyncio" },
     { name = "python-dotenv" },
@@ -333,7 +332,6 @@ requires-dist = [
     { name = "google-cloud-storage", specifier = ">=3.2.0" },
     { name = "google-genai", specifier = ">=1.21.1" },
     { name = "json-repair", specifier = "~=0.40.0" },
-    { name = "pycountry", specifier = ">=24.6.1" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
@@ -849,15 +847,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
-]
-
-[[package]]
-name = "pycountry"
-version = "24.6.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/57/c389fa68c50590881a75b7883eeb3dc15e9e73a0fdc001cdd45c13290c92/pycountry-24.6.1.tar.gz", hash = "sha256:b61b3faccea67f87d10c1f2b0fc0be714409e8fcdcc1315613174f6466c10221", size = 6043910, upload-time = "2024-06-01T04:12:15.05Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/ec/1fb891d8a2660716aadb2143235481d15ed1cbfe3ad669194690b0604492/pycountry-24.6.1-py3-none-any.whl", hash = "sha256:f1a4fb391cd7214f8eefd39556d740adcc233c778a27f8942c8dca351d6ce06f", size = 6335189, upload-time = "2024-06-01T04:11:49.711Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes [#1352](https://linear.app/fullfact/issue/AI-1352/make-country-codes-optional-in-pastel).

Remove country codes entirely from PaS because it should be multi-country.