### PR TITLE
feat: added transcript search as an inference method

### DIFF
--- a/scripts/demos/transcript_search_demo.py
+++ b/scripts/demos/transcript_search_demo.py
@@ -1,0 +1,63 @@
+import asyncio
+import json
+from pathlib import Path
+from typing import TypedDict
+from uuid import UUID
+
+from harmful_claim_finder.transcript_search import get_claims
+from harmful_claim_finder.utils.models import TranscriptSentence
+
+
+class TranscriptFragment(TypedDict):
+    text: str
+    start: float
+    duration: float
+
+
+transcripts = [
+    "data/example_transcripts/9V1U_hnxEjo.json",
+    "data/example_transcripts/8PqlzOVfciQ.json",
+    "data/example_transcripts/noNa3WUGpC8.json",
+    "data/example_transcripts/kMWlOcjBdMc.json",
+    "data/example_transcripts/uIFSvnB1WlQ.json",
+]
+
+video_id = UUID("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+
+def find_checkworthy_claims() -> None:
+    output = {}
+    kw = {
+        "vaccines": ["covid-19", "vaxxer", "vaccine"],
+        "miracle_cures": ["miracle cure", "magic herbs", "traditional medicine"],
+    }
+    output = {}
+    for transcript_path in transcripts:
+        try:
+            transcript: list[TranscriptFragment] = json.loads(
+                Path(transcript_path).read_text()
+            )
+            sentences = [
+                TranscriptSentence(
+                    video_id=video_id,
+                    source="",
+                    text=fragment["text"],
+                    start_time_s=fragment["start"],
+                )
+                for fragment in transcript
+            ]
+            claims = asyncio.run(get_claims(kw, sentences))
+            print(f"Found {len(claims)} claims in transcript {transcript_path}")
+            jsonable = [claim.model_dump(mode="json") for claim in claims]
+            output[transcript_path] = jsonable
+        except Exception as exc:
+            print(f"Something went wrong with {transcript_path}: {repr(exc)}")
+            continue
+
+    Path("output_transcript_search_demo.json").write_text(
+        json.dumps(output, indent=4, ensure_ascii=False)
+    )
+
+
+if __name__ == "__main__":
+    find_checkworthy_claims()

--- a/src/harmful_claim_finder/transcript_search.py
+++ b/src/harmful_claim_finder/transcript_search.py
@@ -1,0 +1,48 @@
+"""
+Searches a video transcript for claims.
+Does not make the assumption that a sentence is a claim.
+Claims can span more than one sentence, or be a span within a sentence.
+"""
+
+from harmful_claim_finder.claim_extraction import extract_claims_from_transcript
+from harmful_claim_finder.pastel.inference import CheckworthyClaimDetector
+from harmful_claim_finder.utils.models import TranscriptSentence, VideoClaims
+
+
+async def get_claims(
+    keywords: dict[str, list[str]],
+    transcript: list[TranscriptSentence],
+) -> list[VideoClaims]:
+    """
+    Retrieve claims from a video transcript.
+    Claims can be more than one sentence, or part of a sentence.
+
+    Args:
+        keywords (dict[str, list[str]]):
+            A {topic: keywords} dictionary containing the kw for each topic. E.g.
+            ```python
+            {
+                "crime": ["police", "robbers"],
+                "health": ["doctor", "hospital"],
+            }
+            ```
+        transcript (list[TranscriptSentence]):
+            The transcript you want to search for claims.
+
+    Returns:
+        list[VideoClaims]
+            A list of claims, marked up with scores.
+    """
+    claims: list[VideoClaims] = await extract_claims_from_transcript(
+        transcript=transcript, keywords=keywords, max_attempts=2
+    )
+    pastel = CheckworthyClaimDetector()
+    claims_text = [claim.claim for claim in claims]
+    scores = await pastel.score_sentences(claims_text, max_attempts=2)
+
+    for claim, score in zip(claims, scores):
+        claim.metadata = (
+            {**claim.metadata, "score": score} if claim.metadata else {"score": score}
+        )
+
+    return claims

--- a/tests/harmful_claim_finder/test_transcript_search.py
+++ b/tests/harmful_claim_finder/test_transcript_search.py
@@ -1,0 +1,62 @@
+from unittest.mock import Mock, patch
+from uuid import UUID
+
+from harmful_claim_finder.pastel.inference import CheckworthyClaimDetector
+from harmful_claim_finder.utils.models import VideoClaims
+from harmful_claim_finder.transcript_search import get_claims
+
+fake_id = UUID("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+unscored_claims = [
+    VideoClaims(
+        video_id=fake_id,
+        claim="claim 1",
+        start_time_s=0,
+        metadata={"quote": "quote 1"},
+    ),
+    VideoClaims(
+        video_id=fake_id,
+        claim="claim 2",
+        start_time_s=1,
+        metadata={"quote": "quote 2"},
+    ),
+    VideoClaims(
+        video_id=fake_id,
+        claim="claim 3",
+        start_time_s=2,
+        metadata={"quote": "quote 3"},
+    ),
+]
+
+scored_claims = [
+    VideoClaims(
+        video_id=fake_id,
+        claim="claim 1",
+        start_time_s=0,
+        metadata={"quote": "quote 1", "score": 0.9},
+    ),
+    VideoClaims(
+        video_id=fake_id,
+        claim="claim 2",
+        start_time_s=1,
+        metadata={"quote": "quote 2", "score": 0.2},
+    ),
+    VideoClaims(
+        video_id=fake_id,
+        claim="claim 3",
+        start_time_s=2,
+        metadata={"quote": "quote 3", "score": 0},
+    ),
+]
+
+
+@patch("harmful_claim_finder.transcript_search.CheckworthyClaimDetector")
+@patch("harmful_claim_finder.transcript_search.extract_claims_from_transcript")
+async def test_output_format(mock_extract_claims, mock_pastel):
+    mock_extract_claims.return_value = unscored_claims
+    mock_pastel_class = Mock(CheckworthyClaimDetector)
+    mock_pastel_class.score_sentences.return_value = [0.9, 0.2, 0]
+    mock_pastel.return_value = mock_pastel_class
+    kw = {"topic": ["keyword"]}
+    output = await get_claims(kw, [])
+    assert output == scored_claims


### PR DESCRIPTION
Adds a new inference method which searches the transcript for claims.

The actual functionality was already in the code, but there was no function for external bits of code to call, equivalent to video_inference or transcript_inference.

The new method is called transcript_search, and it does the same thing as video_inference, but taking text as input instead of a video file.