### PR TITLE
feat: add billing labels for genai calls

### DIFF
--- a/src/harmful_claim_finder/claim_extraction.py
+++ b/src/harmful_claim_finder/claim_extraction.py
@@ -207,6 +207,9 @@ async def _get_transcript_claims(
         prompt,
         system_instruction=CLAIMS_INSTRUCTION_TEXT,
         output_schema=list[TextClaimSchema],
+        labels={
+            "feature": "get_transcript_claims",
+        },
     )
     try:
         claims = _parse_transcript_claims(response, transcript)
@@ -215,6 +218,9 @@ async def _get_transcript_claims(
         fixed_response = await run_prompt_async(
             FIX_JSON.replace("{TEXT}", response),
             output_schema=list[TextClaimSchema],
+            labels={
+                "feature": "get_transcript_claims/fix_json",
+            },
         )
         claims = _parse_transcript_claims(fixed_response, transcript)
 
@@ -285,6 +291,9 @@ async def _get_video_claims(
         video_uri=video_uri,
         system_instruction=CLAIMS_INSTRUCTION_VIDEO,
         output_schema=list[VideoClaimSchema],
+        labels={
+            "feature": "get_video_claims",
+        },
     )
     try:
         claims = _parse_video_claims(response, video_id)
@@ -293,6 +302,9 @@ async def _get_video_claims(
         fixed_response = await run_prompt_async(
             FIX_JSON.replace("{TEXT}", response),
             output_schema=list[VideoClaimSchema],
+            labels={
+                "feature": "get_video_claims/fix_json",
+            },
         )
         claims = _parse_video_claims(fixed_response, video_id)
     return claims

--- a/src/harmful_claim_finder/keyword_filter/topic_keyword_filter.py
+++ b/src/harmful_claim_finder/keyword_filter/topic_keyword_filter.py
@@ -64,7 +64,7 @@ class TopicKeywordFilter:
             Dict of topic numbers (as strings) mapping back to topic names.
         """
         mapped_keywords = mapped_keywords = {
-            f"{i+1}": words for i, words in enumerate(self.keywords.values())
+            f"{i + 1}": words for i, words in enumerate(self.keywords.values())
         }
         topic_name_map = {
             mapped: unmapped
@@ -242,14 +242,22 @@ class TopicKeywordFilter:
         for _ in range(max_attempts):
             try:
                 prompt = self.make_keyword_prompt(article)
-                response = await run_prompt_async(prompt)
+                response = await run_prompt_async(
+                    prompt,
+                    labels={
+                        "feature": "run_all_for_article",
+                    },
+                )
                 result = self.parse(response)
                 try:
                     formatted_result = self.format_results(result, article)
                 except ParsingError:
                     logger.info(f"Parsing error: {traceback.format_exc()}")
                     fixed_json = await run_prompt_async(
-                        FIX_JSON.replace("{INPUT_TEXT}", response)
+                        FIX_JSON.replace("{INPUT_TEXT}", response),
+                        labels={
+                            "feature": "run_all_for_article/fix_json",
+                        },
                     )
                     fixed_result = self.parse(fixed_json)
                     formatted_result = self.format_results(fixed_result, article)


### PR DESCRIPTION
Closes https://linear.app/fullfact/issue/AI-1907/add-billing-labels-to-pas

Adds some basic billing labels so we can track where spend is going. 

We might always want to know what service is making these calls, but we can use ENV vars to set these.